### PR TITLE
allow .match to accept strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,6 @@ expect([]).to.be.an('array');  // works
 expect([]).to.be.an('object'); // works too, since it uses `typeof`
 
 // constructors
-expect(5).to.be.a(Number);
 expect([]).to.be.an(Array);
 expect(tobi).to.be.a(Ferret);
 expect(person).to.be.a(Mammal);

--- a/README.md
+++ b/README.md
@@ -130,9 +130,10 @@ expect({ a: 'b', c: 'd' }).to.only.have.keys(['a', 'c']);
 expect({ a: 'b', c: 'd' }).to.not.only.have.key('a');
 ```
 
-**throwException**/**throwError**: asserts that the `Function` throws or not when called
+**throw**/**throwException**/**throwError**: asserts that the `Function` throws or not when called
 
 ```js
+expect(fn).to.throw(); // synonym of throwException
 expect(fn).to.throwError(); // synonym of throwException
 expect(fn).to.throwException(function (e) { // get the exception object
   expect(e).to.be.a(SyntaxError);
@@ -207,7 +208,7 @@ and shown/processed by the test runner.
 
 ## Differences with should.js
 
-- No need for static `should` methods like `should.strictEqual`. For example, 
+- No need for static `should` methods like `should.strictEqual`. For example,
   `expect(obj).to.be(undefined)` works well.
 - Some API simplifications / changes.
 - API changes related to browser compatibility.

--- a/index.js
+++ b/index.js
@@ -138,6 +138,7 @@
    * @api public
    */
 
+  Assertion.prototype['throw'] =
   Assertion.prototype.throwError =
   Assertion.prototype.throwException = function (fn) {
     expect(this.obj).to.be.a('function');
@@ -637,7 +638,7 @@
       if (isDate(value) && $keys.length === 0) {
         return stylize(value.toUTCString(), 'date');
       }
-      
+
       // Error objects can be shortcutted
       if (value instanceof Error) {
         return stylize("["+value.toString()+"]", 'Error');

--- a/index.js
+++ b/index.js
@@ -326,6 +326,7 @@
    */
 
   Assertion.prototype.match = function (regexp) {
+    if (!regexp.exec) regexp = new RegExp(regexp);
     this.assert(
         regexp.exec(this.obj)
       , function(){ return 'expected ' + i(this.obj) + ' to match ' + regexp }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
     "name": "expect.js"
   , "version": "0.3.1"
   , "description": "BDD style assertions for node and the browser."
+  , "scripts": {
+    "test": "mocha --require ./test/common --growl test/expect.js"
+  }
   , "repository": {
         "type": "git",
         "url": "git://github.com/LearnBoost/expect.js.git"

--- a/test/common.js
+++ b/test/common.js
@@ -4,4 +4,4 @@
  */
 
 // expose the globals that are obtained through `<script>` on the browser
-expect = require('../expect')
+expect = require('../')

--- a/test/expect.js
+++ b/test/expect.js
@@ -156,6 +156,14 @@ describe('expect', function () {
 
     expect(called).to.be(false);
 
+    var called2 = false;
+
+    expect(itWorks).to.not.throw(function () {
+      called2 = true;
+    });
+
+    expect(called2).to.be(false);
+
     err(function () {
       expect(5).to.throwException();
     }, 'expected 5 to be a function');
@@ -382,7 +390,7 @@ describe('expect', function () {
     err(function () {
       expect('asd').to.have.property('foo');
     }, "expected 'asd' to have a property 'foo'");
-    
+
     err(function () {
       expect({ length: undefined }).to.not.have.property('length');
     }, "expected { length: undefined } to not have a property 'length'");
@@ -403,7 +411,7 @@ describe('expect', function () {
     err(function () {
       expect('asd').to.not.have.property('foo', 3);
     }, "'asd' has no property 'foo'");
-    
+
     err(function () {
       expect({ length: undefined }).to.not.have.property('length', undefined);
     }, "expected { length: undefined } to not have a property 'length'");


### PR DESCRIPTION
I'm more than happy to add tests and update documentation, etc, if this change would be received well. Thoughts?

Rationale: I frequently have assertions that must match values that must be assembled (and thus can't be literal regexes). It would look much cleaner and be easier if `.match` did the string -> regex coercion for me, if given a string.
