### PR TITLE
allow .match to accept strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -333,6 +333,7 @@
    */
 
   Assertion.prototype.match = function (regexp) {
+    if (!regexp.exec) regexp = new RegExp(regexp);
     this.assert(
         regexp.exec(this.obj)
       , function(){ return 'expected ' + i(this.obj) + ' to match ' + regexp }


### PR DESCRIPTION
I'm more than happy to add tests and update documentation, etc, if this change would be received well. Thoughts?

Rationale: I frequently have assertions that must match values that must be assembled (and thus can't be literal regexes). It would look much cleaner and be easier if .match did the string -> regex coercion for me, if given a string.
